### PR TITLE
Add release handling using Github Actions

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CD
 
 on:
   workflow_dispatch:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -47,4 +47,4 @@ jobs:
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
           draft: ${{ env.RELEASE_AS_DRAFT }}
-          files: ${{ matrix.os }}-${{ matrix.arch }}-binary
+          files: thyra-server_${{ matrix.os }}_${{ matrix.arch }}

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: "Version to produce"
+        required: true
+      release-as-draft:
+        description: "Whether it's a draft or not"
+        required: true
+        type: boolean
+
+env:
+  GO_VERSION: 1.19
+  RELEASE_VERSION: ${{ github.event.inputs.release-version }}
+  RELEASE_AS_DRAFT: ${{ github.event.inputs.release-as-draft }}
+
+jobs:
+  lint:
+    name: Build and create release
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            os: windows
+          - arch: amd64
+            os: linux
+          - arch: amd64
+            os: darwin
+          - arch: arm64
+            os: darwin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - uses: actions/checkout@v3
+      - name: Build binary for ${{ matrix.os }} on ${{ matrix.arch}}
+        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o thyra-server_${{ matrix.os }}_${{ matrix.arch }} ./cmd/thyra-server/
+      - name: Upload Go test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.os }}-${{ matrix.arch }}-binary
+          path: thyra-server_${{ matrix.os }}_${{ matrix.arch }}
+      - uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.RELEASE_VERSION }}
+          draft: ${{ env.RELEASE_AS_DRAFT }}
+          files: ${{ matrix.os }}-${{ matrix.arch }}-binary

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -12,7 +12,7 @@ on:
         type: boolean
         default: true
       release-as-prerelease:
-        description: "Whether it's a prerlease or not"
+        description: "Whether it's a prerelease or not"
         required: true
         type: boolean
         default: false

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,4 +1,4 @@
-name: ${{ github.event.inputs.release-version }} deployment
+name: CD
 
 on:
   workflow_dispatch:
@@ -24,7 +24,7 @@ env:
   GENERATE_RELEASE_NOTES: ${{ github.event.inputs.generate-release-notes }}
 
 jobs:
-  lint:
+  build-release:
     name: Build and create release
     strategy:
       matrix:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -10,11 +10,18 @@ on:
         description: "Whether it's a draft or not"
         required: true
         type: boolean
+        default: true
+      generate-release-notes:
+        description: "Generate release notes"
+        required: true
+        type: boolean
+        default: true
 
 env:
   GO_VERSION: 1.19
   RELEASE_VERSION: ${{ github.event.inputs.release-version }}
   RELEASE_AS_DRAFT: ${{ github.event.inputs.release-as-draft }}
+  GENERATE_RELEASE_NOTES: ${{ github.event.inputs.generate-release-notes }}
 
 jobs:
   lint:
@@ -38,13 +45,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build binary for ${{ matrix.os }} on ${{ matrix.arch}}
         run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o thyra-server_${{ matrix.os }}_${{ matrix.arch }} ./cmd/thyra-server/
-      - name: Upload Go test results
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.os }}-${{ matrix.arch }}-binary
-          path: thyra-server_${{ matrix.os }}_${{ matrix.arch }}
-      - uses: softprops/action-gh-release@v1
+      - name: Create release and upload binaries
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
           draft: ${{ env.RELEASE_AS_DRAFT }}
+          generate_release_notes: ${{ env.GENERATE_RELEASE_NOTES }}
           files: thyra-server_${{ matrix.os }}_${{ matrix.arch }}

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,4 +1,4 @@
-name: CD
+name: ${{ github.event.inputs.release-version }} deployment
 
 on:
   workflow_dispatch:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -11,6 +11,11 @@ on:
         required: true
         type: boolean
         default: true
+      release-as-prerelease:
+        description: "Whether it's a draft or not"
+        required: true
+        type: boolean
+        default: false
       generate-release-notes:
         description: "Generate release notes"
         required: true
@@ -21,6 +26,7 @@ env:
   GO_VERSION: 1.19
   RELEASE_VERSION: ${{ github.event.inputs.release-version }}
   RELEASE_AS_DRAFT: ${{ github.event.inputs.release-as-draft }}
+  RELEASE_AS_PRERELEASE: ${{ github.event.inputs.release-as-prerelease }}
   GENERATE_RELEASE_NOTES: ${{ github.event.inputs.generate-release-notes }}
 
 jobs:
@@ -50,5 +56,6 @@ jobs:
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
           draft: ${{ env.RELEASE_AS_DRAFT }}
+          prerelease: ${{ env.RELEASE_AS_PRERELEASE }}
           generate_release_notes: ${{ env.GENERATE_RELEASE_NOTES }}
           files: thyra-server_${{ matrix.os }}_${{ matrix.arch }}

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -12,7 +12,7 @@ on:
         type: boolean
         default: true
       release-as-prerelease:
-        description: "Whether it's a draft or not"
+        description: "Whether it's a prerlease or not"
         required: true
         type: boolean
         default: false


### PR DESCRIPTION
This workflow will allow us to create release easily and automatically add binaries to a release as release assets.