### PR TITLE
improve quit gui

### DIFF
--- a/int/api/server.go
+++ b/int/api/server.go
@@ -104,10 +104,10 @@ func StartServer(app *fyne.App) {
 
 	server.ConfigureAPI()
 
+	defer (*app).Quit()
+
 	if err := server.Serve(); err != nil {
 		//nolint:gocritic
 		log.Fatalln(err)
 	}
-
-	(*app).Quit()
 }


### PR DESCRIPTION
The application was not quit properly. This PR defers the call to the quit function to execute it in any case.

Before this PR, the bug was that the application was still running event after submitting the password.
<img width="83" alt="Screenshot 2022-11-07 at 10 53 25" src="https://user-images.githubusercontent.com/11590067/200280635-b7eb903a-4cb1-47b9-a83b-55c68c89f147.png">
