### PR TITLE
Read file as binary instead of b64 string

### DIFF
--- a/int/api/html/front/website.js
+++ b/int/api/html/front/website.js
@@ -307,7 +307,7 @@ $(".website-dns input").on("change", function () {
 function uploadProcess(file, dnsName, isFullProcess, bodyFormData, callback) {
     document.getElementById("wallet-popover").classList.add("popover__disabled");
     const reader = new FileReader();
-    reader.readAsDataURL(file);
+    reader.readAsBinaryString(file);
     reader.onloadend = (_) => {
         const result = reader.result.length;
 


### PR DESCRIPTION
The chunk size was computed with b64 encoded data. Now it's computed with binary data to match our new model.