### PR TITLE
Fix Windows build on main.

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -14,7 +14,7 @@ runs:
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: installing linux dependencies
-      if: ${{ inputs.os == 'ubuntu-20.04' }}
+      if: startsWith(inputs.os, 'ubuntu-')
       shell: bash
       run: |
         sudo apt update


### PR DESCRIPTION
The Windows build in the `build` workflow [uses `ubuntu-latest`](https://github.com/massalabs/thyra/blob/00a04424e6a693eb660d9478e310811b3b00f555/.github/workflows/build.yml#L38).

So we need to check if the `inputs.os` starts with `ubuntu-` instead of checking for a perfect match.