### PR TITLE
Fix for MIME type handling

### DIFF
--- a/pkg/onchain/website/browser.go
+++ b/pkg/onchain/website/browser.go
@@ -30,18 +30,96 @@ func removeEmptyStrings(s []string) []string {
 	return result
 }
 
+// Common MIME types from https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+var contentTypeMap = map[string]string{
+	".aac":    "audio/aac",
+	".abw":    "application/x-abiword",
+	".arc":    "application/x-freearc",
+	".avi":    "video/x-msvideo",
+	".azw":    "application/vnd.amazon.ebook",
+	".bin":    "application/octet-stream",
+	".bmp":    "image/bmp",
+	".bz":     "application/x-bzip",
+	".bz2":    "application/x-bzip2",
+	".csh":    "application/x-csh",
+	".css":    "text/css",
+	".csv":    "text/csv",
+	".doc":    "application/msword",
+	".docx":   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+	".eot":    "application/vnd.ms-fontobject",
+	".epub":   "application/epub+zip",
+	".gz":     "application/gzip",
+	".gif":    "image/gif",
+	".htm":    "text/html",
+	".html":   "text/html",
+	".ico":    "image/vnd.microsoft.icon",
+	".ics":    "text/calendar",
+	".jar":    "application/java-archive",
+	".jpeg":   "image/jpeg",
+	".jpg":    "image/jpeg",
+	".js":     "text/javascript",
+	".json":   "application/json",
+	".jsonld": "application/ld+json",
+	".mid":    "audio/midi",
+	".midi":   "audio/midi",
+	".mjs":    "text/javascript",
+	".mp3":    "audio/mpeg",
+	".mpeg":   "video/mpeg",
+	".mpkg":   "application/vnd.apple.installer+xml",
+	".odp":    "application/vnd.oasis.opendocument.presentation",
+	".ods":    "application/vnd.oasis.opendocument.spreadsheet",
+	".odt":    "application/vnd.oasis.opendocument.text",
+	".oga":    "audio/ogg",
+	".ogv":    "video/ogg",
+	".ogx":    "application/ogg",
+	".opus":   "audio/opus",
+	".otf":    "font/otf",
+	".png":    "image/png",
+	".pdf":    "application/pdf",
+	".php":    "application/x-httpd-php",
+	".ppt":    "application/vnd.ms-powerpoint",
+	".pptx":   "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+	".rar":    "application/vnd.rar",
+	".rtf":    "application/rtf",
+	".sh":     "application/x-sh",
+	".svg":    "image/svg+xml",
+	".swf":    "application/x-shockwave-flash",
+	".tar":    "application/x-tar",
+	".tif":    "image/tiff",
+	".tiff":   "image/tiff",
+	".ts":     "video/mp2t",
+	".ttf":    "font/ttf",
+	".txt":    "text/plain",
+	".vsd":    "application/vnd.visio",
+	".wav":    "audio/wav",
+	".weba":   "audio/webm",
+	".webm":   "video/webm",
+	".webp":   "image/webp",
+	".woff":   "font/woff",
+	".woff2":  "font/woff2",
+	".xhtml":  "application/xhtml+xml",
+	".xls":    "application/vnd.ms-excel",
+	".xlsx":   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+	".xml":    "application/xml",
+	".xul":    "application/vnd.mozilla.xul+xml",
+	".zip":    "application/zip",
+	".3gp":    "video/3gpp",
+	".3g2":    "video/3gpp2",
+	".7z":     "application/x-7z-compressed",
+}
+
 func setContentType(rsc string, writer http.ResponseWriter) {
-	switch filepath.Ext(rsc) {
-	case ".css":
-		writer.Header().Set("Content-Type", "text/css")
-	case ".js":
-		writer.Header().Set("Content-Type", "application/json")
-	case ".html":
-		writer.Header().Set("Content-Type", "text/html")
-	case ".webp":
-		writer.Header().Set("Content-Type", "text/webp")
-	case ".png":
-		writer.Header().Set("Content-Type", "image/png")
+	ext := filepath.Ext(rsc)
+
+	if ext == "" {
+		writer.Header().Set("Content-Type", "text/plain")
+		return
+	}
+
+	if contentType, ok := contentTypeMap[ext]; ok {
+		writer.Header().Set("Content-Type", contentType)
+	} else {
+		writer.Header().Set("Content-Type", "text/plain")
 	}
 }
 


### PR DESCRIPTION

Hello,

I have fixed an issue with the MIME type handling in the server. The problem was that the server was not properly handling MIME types for certain file extensions, which caused errors when loading scripts and other resources.

For example when uploading a website that was built with react, the javascript files weren’t accepted as valid javascript modules since thyra marked them as json.

I have added common MIME types i found on [MDM](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types). I updated the setContentType function to handle the vast majority of extensions.

I have tested the changes and they are working correctly. I would like to request that these changes be included in the main branch.

Thank you for your time and consideration.