### PR TITLE
remove full install from lint workflow

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -26,6 +26,7 @@ runs:
         cache-dependency-path: |
           web/thyra-frontend/package-lock.json
           web/plugin-manager/package-lock.json
+
     - name: Build react frontend
       shell: bash
       run: go generate ./web/...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/install
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:


### PR DESCRIPTION
To speedUp the CI, Only do the minimum for the linting process to run.

This save around 45 seconds !