### PR TITLE
474-improve-thyra-installation-scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           files: thyra-server_${{ matrix.target }}_${{ matrix.arch }}
 
   build-installer:
-    if: ${{ (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') }}
+#    if: ${{ (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') }}
     needs: [lint, tests]
     name: build and upload installers binaries
     strategy:
@@ -94,16 +94,19 @@ jobs:
             target: darwin
             script: scripts/macos_installer.py
             displayed_arch: amd64
+            ext: .tar.gz
           - os: macos-latest
             arch: arm64
             target: darwin
             script: scripts/macos_installer.py
             displayed_arch: arm64
+            ext: .tar.gz
           - os: ubuntu-latest
             arch: amd64
             target: linux
             script: scripts/linux_installer.py
             displayed_arch: amd64
+            ext: .tar.gz
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -114,6 +117,10 @@ jobs:
       - name: Build installer binary
         run: |
           pyinstaller --clean --onefile -y --target-arch ${{ matrix.arch }} --dist ./dist/${{ matrix.target }} --workpath /tmp ${{ matrix.script }} --name thyra-installer_${{ matrix.target }}_${{ matrix.displayed_arch }}
+      - name: Archive installer binary
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: |
+          tar -czvf thyra-installer_${{ matrix.target }}_${{ matrix.displayed_arch }}${{ matrix.ext }} -C ./dist/${{ matrix.target }} thyra-installer_${{ matrix.target }}_${{ matrix.displayed_arch }}
       - name: Upload installer artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           files: thyra-server_${{ matrix.target }}_${{ matrix.arch }}
 
   build-installer:
-#    if: ${{ (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') }}
     needs: [lint, tests]
     name: build and upload installers binaries
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Archive installer binary
         if: ${{ matrix.os != 'windows-latest' }}
         run: |
-          tar -czvf thyra-installer_${{ matrix.target }}_${{ matrix.displayed_arch }}${{ matrix.ext }} -C ./dist/${{ matrix.target }} thyra-installer_${{ matrix.target }}_${{ matrix.displayed_arch }}
+          tar -czvf ./dist/${{ matrix.target }}/thyra-installer_${{ matrix.target }}_${{ matrix.displayed_arch }}${{ matrix.ext }} -C ./dist/${{ matrix.target }} thyra-installer_${{ matrix.target }}_${{ matrix.displayed_arch }}
       - name: Upload installer artifacts
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This PR focusses on fixing the lack of permissions installer binaries.

Please check that you can run the installer binary from [the latest build](https://github.com/massalabs/thyra/actions/runs/4386599576). (without having to `chmod +x` the binary)