### PR TITLE
Fix an error due to a misplaced mutex unlock in Plugin Start function

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -119,6 +119,7 @@ func (p *Plugin) Start() error {
 	log.Printf("Starting plugin '%s' with id %s\n", pluginName, p.ID)
 
 	p.mutex.Lock()
+	defer p.mutex.Unlock()
 
 	status := p.Status()
 
@@ -154,8 +155,6 @@ func (p *Plugin) Start() error {
 	}()
 
 	p.status = Up
-
-	p.mutex.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
In some cases, like trying to execute the `start` command on a plugin that was already running, the function exited with an error and the lock was never released. 
This PR fixes this issue.