### PR TITLE
Add Plugin Store tests

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Prepare thyra to be runned
         run: mkdir /home/runner/.config/thyra && sudo setcap CAP_NET_BIND_SERVICE=+eip ./main && sudo apt install xvfb
       - name: Running thyra
-        run: xvfb-run ./main --node-server ${{ NODE_SERVER }} &
+        run: xvfb-run ./main --node-server $NODE_SERVER &
       - name: Define my.massa
         run: sudo echo "127.0.0.1 my.massa" | sudo tee -a /etc/hosts
       - name: Test plugin manager API
@@ -53,7 +53,7 @@ jobs:
       - name: Prepare thyra to be runned
         run: mkdir /home/runner/.config/thyra && sudo setcap CAP_NET_BIND_SERVICE=+eip ./main
       - name: Running thyra
-        run: xvfb-run ./main --node-server ${{ NODE_SERVER }} &
+        run: xvfb-run ./main --node-server $NODE_SERVER &
       - name: Define my.massa
         run: sudo echo "127.0.0.1 my.massa" | sudo tee -a /etc/hosts
       - name: Wait for server to be up

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -2,6 +2,10 @@ name: API
 
 on:
   push:
+
+env:
+  NODE_SERVER: INNONET
+
 jobs:
   test-api:
     runs-on: ubuntu-latest
@@ -19,7 +23,7 @@ jobs:
       - name: Prepare thyra to be runned
         run: mkdir /home/runner/.config/thyra && sudo setcap CAP_NET_BIND_SERVICE=+eip ./main && sudo apt install xvfb
       - name: Running thyra
-        run: xvfb-run ./main &
+        run: xvfb-run ./main --node-server ${{ NODE_SERVER }} &
       - name: Define my.massa
         run: sudo echo "127.0.0.1 my.massa" | sudo tee -a /etc/hosts
       - name: Test plugin manager API
@@ -49,7 +53,7 @@ jobs:
       - name: Prepare thyra to be runned
         run: mkdir /home/runner/.config/thyra && sudo setcap CAP_NET_BIND_SERVICE=+eip ./main
       - name: Running thyra
-        run: xvfb-run ./main &
+        run: xvfb-run ./main --node-server ${{ NODE_SERVER }} &
       - name: Define my.massa
         run: sudo echo "127.0.0.1 my.massa" | sudo tee -a /etc/hosts
       - name: Wait for server to be up

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 env:
-  NODE_SERVER: INNONET
+  NODE_SERVER: TESTNET
 
 jobs:
   test-api:

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 env:
-  NODE_SERVER: TESTNET
+  NODE_SERVER: INNONET
 
 jobs:
   test-api:

--- a/api/test/robot_tests/plugin_store/plugin_store.robot
+++ b/api/test/robot_tests/plugin_store/plugin_store.robot
@@ -1,0 +1,16 @@
+*** Settings ***
+Documentation       This is a test suite for Thyra Plugin Store endpoints.
+
+Library             RequestsLibrary
+Resource            ../variables.resource
+Resource            ../keywords.resource
+
+Suite Setup         Basic Suite Setup
+
+
+*** Test Cases ***
+GET /plugin-store
+    ${response}=    GET    ${API_URL}/plugin-store
+    Should Be Equal As Strings    ${response[0]['name']}    Node Manager
+    Should Be Equal As Strings    ${response[0]['description']}    Install and manage Massa nodes from Thyra
+    Should Be Equal As Strings    ${response[0]['url']}    https://github.com/massalabs/thyra-node-manager-plugin

--- a/api/test/robot_tests/plugin_store/plugin_store.robot
+++ b/api/test/robot_tests/plugin_store/plugin_store.robot
@@ -11,6 +11,7 @@ Suite Setup         Basic Suite Setup
 *** Test Cases ***
 GET /plugin-store
     ${response}=    GET    ${API_URL}/plugin-store
+    ${response}=    Set Variable    ${response.json()}
     Should Be Equal As Strings    ${response[0]['name']}    Node Manager
     Should Be Equal As Strings    ${response[0]['description']}    Install and manage Massa nodes from Thyra
     Should Be Equal As Strings    ${response[0]['url']}    https://github.com/massalabs/thyra-node-manager-plugin


### PR DESCRIPTION
I added the variable for `node-server` just to make sure tests are working properly. As discussed with the team, I put back `node-server` to `TESTNET`. 

You can see [b58cad9](https://github.com/massalabs/thyra/pull/586/commits/b58cad95ef459855fddfd740bd764d4297e51702) which contains the tests running on `INNONET`.