### PR TITLE
Install Thyra Hyperlink 404 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To contribute to this project, please read our [Contributor's Guide](./CONTRIBUT
 
 
 ## Install thyra 
-To install Thyra, please follow the instructions available in the [Installation Guide](./INSTALL.md).
+To install Thyra, please follow the instructions available in the [Installation Guide](./INSTALLATION.md).
 
 ## Install a plugin
 


### PR DESCRIPTION
Fixed the redirection towards the installation guide from [Installation Guide](./INSTALL.md) to [Installation Guide](./INSTALLATION.md). Previously while trying to access the install guide it would return a 404 page not found. 