### PR TITLE
fix ignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.exe
-massastation
+/massastation
 
 *.log
 *.spec


### PR DESCRIPTION
We are fixing rule in `.gitignore` to allow pushing `massastation` directory.